### PR TITLE
UpdateWorkout mutation

### DIFF
--- a/fittrak/fittrak/schema.py
+++ b/fittrak/fittrak/schema.py
@@ -6,7 +6,7 @@ from graphene_django.types import DjangoObjectType
 from graphene_django.debug import DjangoDebug
 
 from workouts.schema import CreateWorkout, RemoveWorkout, Query as WorkoutsQuery, \
-    AddExercise, AddSet
+    AddExercise, AddSet, UpdateWorkout
 
 from users.schema import Query as UsersQuery
 
@@ -17,6 +17,7 @@ class RootQuery(WorkoutsQuery, UsersQuery, graphene.ObjectType):
 class RootMutation(graphene.ObjectType):
     create_workout = CreateWorkout.Field()
     remove_workout = RemoveWorkout.Field()
+    update_workout = UpdateWorkout.Field()
     add_exercise = AddExercise.Field()
     add_set = AddSet.Field()
 

--- a/fittrak/workouts/schema.py
+++ b/fittrak/workouts/schema.py
@@ -6,7 +6,6 @@ import graphene
 from graphql import GraphQLError
 from graphene_django.types import DjangoObjectType
 
-from fittrak.helpers import convert_to_snake
 from .models import Workout, Exercise, ExerciseType as ExerciseTypeModel, Set
 
 


### PR DESCRIPTION
Added the update workout mutation which is required for finishing #66. Currently this only deals with `date_ended` but can be easily extended for other fields. 

Also ref. #16 

Example usage:
```
mutation ($workoutId:Int!, $workoutFields:WorkoutFieldInputType!) {
  updateWorkout(workoutId: $workoutId, workoutFields: $workoutFields){
    workout {
      id
      dateEnded
    }
  } 
}
```

Variables:
```
{
  "workoutId": 77,
  "workoutFields": {
    "dateEnded": "2018-09-14T23:31:11+00:00"
  }
}
```